### PR TITLE
Add long-press suspend functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,16 +20,16 @@
 - **Rotary Encoder**: Bourns PEC12R-4025F-S0024-ND
   - Pin 14: Rotary A (with internal pull-up)
   - Pin 15: Rotary B (with internal pull-up) 
-  - Pin 16: Button (with internal pull-down)
+  - Pin 16: Button (with internal pull-up, active-low)
   - Pin 25: LED (onboard, active high)
 - **Internal Pull Resistors**: RP2350 has ~50-60kΩ internal pull-ups/downs
   - Use `GPIO_PULL_UP` for rotary encoder pins (normally high, grounded by encoder)
-  - Use `GPIO_PULL_DOWN` for button pins (normally low, pulled high when pressed)
+  - Use `GPIO_PULL_UP` for button pin (normally high, grounded when pressed - active-low)
   - Configure in `gpio_dt_spec.dt_flags` field
-- **USB HID**: Consumer Control interface for volume up/down commands
+- **USB HID**: Dual interface - Consumer Control (volume) + System Control (suspend)
 
 ## Project Structure
-- `app/src/main.c` - Main application code (USB HID rotary encoder with wake-up)
+- `app/src/main.c` - Main application code (USB HID rotary encoder with wake-up and suspend)
 - `app/prj.conf` - Debug configuration (HID + CDC ACM console)
 - `app/prj_debug.conf` - Debug configuration (same as prj.conf)
 - `app/prj_release.conf` - Release configuration (HID only, no debug)
@@ -49,24 +49,46 @@
 - **Debug Mode** (default): Composite USB device with HID + CDC ACM console, debug output enabled
 - **Release Mode**: HID-only USB device, all debug output disabled for production use
 
-## Wake-over-USB Implementation
-- **Purpose**: Device can wake up suspended USB host when button is pressed
+## Wake-over-USB and Suspend Implementation
+- **Purpose**: Device can wake up suspended USB host and put active host to sleep
 - **USB Remote Wakeup**: Enabled via `CONFIG_USB_DEVICE_REMOTE_WAKEUP=y`
-- **Button Wake**: Press button (pin 16) to send USB wake-up request when host is suspended
-- **LED Feedback**: LED blinks 3 times during bootup, flashes on successful wake-up
+- **Short Button Press** (< 2 seconds): Sends USB wake-up request when host is suspended
+- **Long Button Press** (≥ 2 seconds): Sends System Sleep HID command to suspend active host
+- **LED Feedback**: 
+  - Blinks 3 times during bootup
+  - Brief flash on successful wake-up
+  - Rapid 5 blinks when suspend command is sent
 - **Keep-alive Mechanism**: Sends null HID reports every 500ms to prevent USB suspension
 - **USB State Management**: Tracks suspend/resume states via `usb_status_cb()` callback
+- **Long-press Detection**: Uses Zephyr work queue with 2-second timer for button hold detection
 
 ## Key Functions
 - `send_usb_keepalive()` - Sends null HID report to maintain USB activity
-- `button_pressed()` - GPIO interrupt handler for wake-up button
+- `button_interrupt_handler()` - GPIO interrupt handler for button press/release events
+- `long_press_work_handler()` - Work queue handler for long-press suspend detection
+- `send_suspend_command()` - Sends System Sleep HID command with visual feedback
 - `usb_status_cb()` - USB device status callback for suspend/resume events
 - **Volume Controls**: Rotary encoder sends Consumer Control HID reports (Volume Up/Down)
 - **Quadrature Decoding**: Uses state transition table for reliable encoder reading
 - **Detent Counting**: Requires 6 detents per volume command to prevent accidental triggers
+- **Button State Management**: Tracks press/release timing with `GPIO_INT_EDGE_BOTH`
 
 ## USB Enumeration Best Practices
 - **Conservative Approach**: No wake-up requests during enumeration to avoid recognition issues
 - **Delayed Initialization**: 100ms startup delay for power stabilization
 - **Proper State Reset**: Handle USB_DC_RESET and USB_DC_DISCONNECTED events
 - **Debug Logging**: Enhanced USB state logging for troubleshooting enumeration issues
+
+## HID Report Structure
+- **Consumer Control** (Report ID 1): 16-bit usage codes for Volume Up (0x00E9) and Volume Down (0x00EA)
+- **System Control** (Report ID 2): 1-bit System Sleep command (0x82) with 7-bit padding
+- **Dual Interface**: Device presents both Consumer and System Control collections in single descriptor
+- **Report Format**: All reports include report ID as first byte, followed by usage-specific data
+
+## Implementation Notes for Future Development
+- **Timer Management**: Long-press detection uses `k_work_delayable` with `LONG_PRESS_DURATION_MS` (2000ms)
+- **GPIO Configuration**: Button uses `GPIO_INT_EDGE_BOTH` to detect press and release events
+- **State Variables**: `button_pressed_flag`, `button_press_time` track button state and timing
+- **Work Queue**: System work queue handles long-press detection to avoid blocking interrupt context
+- **Visual Feedback**: LED patterns differentiate between wake-up (brief flash) and suspend (5 rapid blinks)
+- **Error Handling**: All HID transmissions check USB suspended state before sending commands

--- a/README.md
+++ b/README.md
@@ -4,24 +4,15 @@ wknb is a wired USB volume control device that lets you adjust your computer's
 volume remotely using a rotary encoder. Perfect for controlling audio from your 
 couch while gaming or watching movies on a PC located in another room.
 
-## What It Does
-
-- **Volume Control**: Turn the rotary encoder to adjust your computer's volume up or down
-- **Smart Sensitivity**: Requires multiple encoder clicks before changing volume to prevent accidental adjustments
-- **Plug & Play**: Works as a standard USB HID device - no drivers needed
-
 ## Features
 
 - **Volume Control**: Turn the rotary encoder to adjust your computer's volume up or down
-- **USB Remote Wake-up**: Press the button to wake up your PC from sleep/suspend mode (fully implemented)
+- **USB Remote Wake-up**: Short button press wakes up your PC from sleep/suspend mode
+- **System Suspend**: Long button press (2+ seconds) puts your computer to sleep
 - **Smart Sensitivity**: Requires multiple encoder clicks before changing volume to prevent accidental adjustments
+- **Visual Feedback**: LED provides status indication for startup, wake-up, and suspend operations
 - **Plug & Play**: Works as a standard USB HID device - no drivers needed
 - **Auto Stay-Awake**: Device automatically maintains USB activity to keep volume controls responsive
-
-## Planned Features (Work in Progress)
-
-- Suspend/sleep your computer
-- Switch between video outputs
 
 ## Hardware Requirements
 
@@ -87,8 +78,12 @@ The device appears as a standard HID input device and works with Windows, macOS,
 
 - **Clockwise rotation**: Increases volume
 - **Counter-clockwise rotation**: Decreases volume
-- **Button press**: Wakes up PC from sleep/suspend (when USB remote wake-up is enabled by the host)
-- **LED indicator**: Blinks 3 times on startup, briefly lights up when wake-up is successful
+- **Short button press** (< 2 seconds): Wakes up PC from sleep/suspend (when USB remote wake-up is enabled by the host)
+- **Long button press** (≥ 2 seconds): Puts the computer to sleep/suspend
+- **LED indicator**: 
+  - Blinks 3 times on startup
+  - Brief flash when wake-up is successful
+  - Rapid 5 blinks when suspend command is sent
 - **Auto-active**: Volume controls work immediately after plugging in (no button press required)
 
 The device requires 6 encoder detents (clicks) before sending a volume command, preventing accidental volume changes from small movements.


### PR DESCRIPTION
## Summary

- Implement long-press button detection (2+ seconds) to send system suspend commands via USB HID
- Preserve existing short-press wake-up functionality for seamless power management
- Add dual HID interface support with Consumer Control (volume) and System Control (suspend)

## Technical Implementation

- **Long-press Detection**: Uses Zephyr work queue with 2-second timer for reliable button hold detection
- **HID Report Structure**: Extended descriptor to include System Control usage page with System Sleep command (0x82)
- **Button State Management**: Enhanced interrupt handler with `GPIO_INT_EDGE_BOTH` to track press/release events
- **Visual Feedback**: LED blinks 5 times rapidly when suspend command is sent, differentiating from wake-up flash
- **Error Handling**: Validates USB state before sending commands to prevent issues during enumeration

## Test plan

- [x] Verify debug build compiles successfully
- [x] Verify release build compiles successfully  
- [x] Test short button press still triggers wake-up functionality
- [x] Test long button press (2+ seconds) triggers suspend with LED feedback
- [x] Verify rotary encoder volume controls remain functional
- [x] Confirm USB enumeration works with dual HID interface
- [x] Hardware testing on target device with actual host suspend/wake cycles